### PR TITLE
✨ FEAT. 세션 종료 기능 구현

### DIFF
--- a/src/main/java/com/hsu/pyeoning/domain/chat/entity/Chat.java
+++ b/src/main/java/com/hsu/pyeoning/domain/chat/entity/Chat.java
@@ -29,6 +29,10 @@ public class Chat extends BaseEntity {
     @Column(name = "chat_content")
     private String chatContent; // 채팅 내용
 
+    @Setter
+    @Column(name = "session_end", nullable = false)
+    private boolean sessionEnd = false; // 세션 종료 플래그, 기본값은 false
+
     // ======== 편의 메서드 ========
     // 채팅 저장 메서드
     public static Chat addChat(String content, Patient patient, boolean isSend) {
@@ -38,5 +42,4 @@ public class Chat extends BaseEntity {
                 .patient(patient)
                 .build();
     }
-
 }

--- a/src/main/java/com/hsu/pyeoning/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/hsu/pyeoning/domain/chat/repository/ChatRepository.java
@@ -1,14 +1,18 @@
 package com.hsu.pyeoning.domain.chat.repository;
 
 import com.hsu.pyeoning.domain.chat.entity.Chat;
+import com.hsu.pyeoning.domain.patient.entity.Patient;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     Page<Chat> findByPatient_PatientId(Long patientId, Pageable pageable);
     Page<Chat> findByPatient_PatientCode(String patientCode, Pageable pageable);
+    // 환자의 가장 최근 메시지 가져오기
+    Optional<Chat> findTopByPatientOrderByCreatedAtDesc(Patient patient);
 }

--- a/src/main/java/com/hsu/pyeoning/domain/chat/service/ChatService.java
+++ b/src/main/java/com/hsu/pyeoning/domain/chat/service/ChatService.java
@@ -9,4 +9,6 @@ public interface ChatService {
     ResponseEntity<CustomApiResponse<?>> getChatContentForPatient(String patientCode, int page, int size);
     // 환자가 채팅 메세지 전송
     ResponseEntity<CustomApiResponse<?>> processChatMessage(ChatMessageRequestDto chatMessageRequestDto);
+    // 세션 종료
+    ResponseEntity<CustomApiResponse<?>> endSessionForPatient();
 }

--- a/src/main/java/com/hsu/pyeoning/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/hsu/pyeoning/domain/chat/service/ChatServiceImpl.java
@@ -9,6 +9,7 @@ import com.hsu.pyeoning.domain.patient.entity.Patient;
 import com.hsu.pyeoning.domain.patient.repository.PatientRepository;
 import com.hsu.pyeoning.global.response.CustomApiResponse;
 import com.hsu.pyeoning.global.security.jwt.util.AuthenticationUserUtils;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -110,9 +111,10 @@ public class ChatServiceImpl implements ChatService {
     }
 
     // 환자가 채팅 메세지 전송
+    @Transactional
     @Override
     public ResponseEntity<CustomApiResponse<?>> processChatMessage(ChatMessageRequestDto chatMessageRequestDto) {
-        String currentUserId = authenticationUserUtils.getCurrentUserId();
+        String currentUserId = authenticationUserUtils.getCurrentUserId(); // patientCode를 반환 ex. LAH8OP2C
 //        System.out.println("currentUserId: "+currentUserId); -> currentUserId: LAH8OP2C
 
         // 401 : 환자 정보 찾을 수 없음
@@ -157,7 +159,23 @@ public class ChatServiceImpl implements ChatService {
 
     // 세션 종료
     @Override
+    @Transactional
     public ResponseEntity<CustomApiResponse<?>> endSessionForPatient() {
-        return null;
+        String currentUserId = authenticationUserUtils.getCurrentUserId(); //patientCode
+
+        // 401 : 환자 정보 찾을 수 없음
+        Patient patient = patientRepository.findByPatientCode(currentUserId)
+                .orElseThrow(() -> new RuntimeException("유효하지 않은 토큰이거나, 해당 ID에 해당하는 환자가 존재하지 않습니다."));
+
+        // 환자의 마지막 채팅 메시지 가져오기
+        Chat lastChat = chatRepository.findTopByPatientOrderByCreatedAtDesc(patient)
+                .orElseThrow(() -> new RuntimeException("채팅 기록이 없습니다."));
+
+        // 세션 종료 플래그 설정
+        lastChat.setSessionEnd(true);
+        chatRepository.save(lastChat);
+
+        // 200 : 세션 종료 성공
+        return ResponseEntity.ok(CustomApiResponse.createSuccess(200, null, "세션이 성공적으로 종료되었습니다."));
     }
 }

--- a/src/main/java/com/hsu/pyeoning/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/hsu/pyeoning/domain/chat/service/ChatServiceImpl.java
@@ -154,4 +154,10 @@ public class ChatServiceImpl implements ChatService {
         // 201 : 메세지 전송 및 AI 응답 생성에 성공
         return ResponseEntity.ok(CustomApiResponse.createSuccess(201, data, "메세지 전송 및 AI 응답 생성에 성공했습니다."));
     }
+
+    // 세션 종료
+    @Override
+    public ResponseEntity<CustomApiResponse<?>> endSessionForPatient() {
+        return null;
+    }
 }

--- a/src/main/java/com/hsu/pyeoning/domain/chat/web/controller/ChatController.java
+++ b/src/main/java/com/hsu/pyeoning/domain/chat/web/controller/ChatController.java
@@ -41,4 +41,10 @@ public class ChatController {
             @Valid @RequestBody ChatMessageRequestDto chatMessageRequestDTO) {
         return chatService.processChatMessage(chatMessageRequestDTO);
     }
+
+    // 세션 종료
+    @PostMapping("/endSession")
+    public ResponseEntity<CustomApiResponse<?>> endChatSession() {
+        return chatService.endSessionForPatient();
+    }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
close #37 

## 🛠️ 변경 사항
- Entity 수정
- 세션 종료 플래그 설정
-  예외처리

## ✅ 체크리스트
- [x] 병합 브랜치 dev 인지 확인
- [x] 적절한 라벨 부착
- [x] 테스트

## 📸 스크린샷
### Postman
1. 200 (세션 종료 성공)
<img width="415" alt="image" src="https://github.com/user-attachments/assets/ad22ed89-c4d2-45ac-b16c-d67d46e6af7b">
<br>
2. 401 (환자 정보 찾을 수 없음)
<br>
<img width="414" alt="image" src="https://github.com/user-attachments/assets/c68afcaa-c89d-4003-b559-4291038e6f45">
<br><br>


### DB 예시 (chat_id = 8, session_end 주목)
<br>
1. 호출 전
<br>
<img width="536" alt="image" src="https://github.com/user-attachments/assets/298f7d2f-7d27-4708-9c00-ad38b04ec34d">
<br>
2. 호출 후
<br>
<img width="528" alt="image" src="https://github.com/user-attachments/assets/80414a0f-e940-4670-9d4e-c5bc8d7c2177">
