### PR TITLE
🚨 FIX. 환자 등록 후 첫 요약보고서 생성 불가 오류 해결

### DIFF
--- a/src/main/java/com/hsu/pyeoning/domain/patient/service/PatientServiceImpl.java
+++ b/src/main/java/com/hsu/pyeoning/domain/patient/service/PatientServiceImpl.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import com.hsu.pyeoning.domain.chat.entity.Chat;
+import com.hsu.pyeoning.domain.chat.repository.ChatRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -36,6 +38,7 @@ public class PatientServiceImpl implements PatientService {
     private final PatientRepository patientRepository;
     private final DoctorRepository doctorRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ChatRepository chatRepository;
 
     @Override
     public ResponseEntity<CustomApiResponse<?>> registerPatient(PatientRegisterDto dto) {
@@ -63,6 +66,15 @@ public class PatientServiceImpl implements PatientService {
                 null,
                 "환자 등록에 성공했습니다."
         );
+
+        // 환자 등록 시 Chat 기본 세팅
+        Chat dafaultChat = Chat.builder()
+                .patient(patient)
+                .chatContent("안녕하세요 펴닝입니다. 무엇을 도와드릴까요?")
+                .chatIsSend(false)
+                .sessionEnd(true)
+                .build();
+        chatRepository.save(dafaultChat);
 
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
## 🔍 관련 이슈
close #46 

## 🛠️ 변경 사항
환자 등록 이후 펴닝과의 첫 대화에 대한 요약보고서가 생성되지 않는 문제 해결
-> 환자 등록 시 기본 Chat 데이터 설정

chat_content : 안녕하세요! 어떤 일로 오셨나요?
session_end : true //핵심


## ✅ 체크리스트

## 📸 스크린샷
- 회원가입 이후 첫 대화에 대한 요약 보고서 생성
<img width="490" alt="image" src="https://github.com/user-attachments/assets/328ab091-c38a-4a46-9ca0-79032da81134">

=> 정상 작동
